### PR TITLE
Cloudbeat CVE automation

### DIFF
--- a/.github/scripts/generate_cve_security_statement.py
+++ b/.github/scripts/generate_cve_security_statement.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Generate a Cloudbeat CVE security statement in YAML format.
+
+The script consumes issue context (title/body/CVE hints), runs govulncheck
+against the current repository, and emits a structured YAML report that can be
+posted back to the originating issue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+CVE_PATTERN = re.compile(r"\bCVE-\d{4}-\d{4,7}\b", re.IGNORECASE)
+SAFE_YAML_SCALAR = re.compile(r"^[A-Za-z0-9._/@:+-]+$")
+RESERVED_YAML_WORDS = {"null", "true", "false", "yes", "no", "on", "off", "~"}
+
+
+@dataclass(frozen=True)
+class FindingView:
+    osv_id: str
+    reachability: str
+    fixed_version: str
+    trace_summary: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate Cloudbeat CVE security statement.")
+    parser.add_argument("--issue-repository", default=os.getenv("ISSUE_REPOSITORY", ""))
+    parser.add_argument("--issue-number", default=os.getenv("ISSUE_NUMBER", ""))
+    parser.add_argument("--issue-title", default=os.getenv("ISSUE_TITLE", ""))
+    parser.add_argument("--issue-body", default=os.getenv("ISSUE_BODY", ""))
+    parser.add_argument("--cve-id", action="append", default=[])
+    parser.add_argument("--trigger-mode", default=os.getenv("TRIGGER_MODE", "manual"))
+    parser.add_argument("--source-repository", default=os.getenv("SOURCE_REPOSITORY", "elastic/cloudbeat"))
+    parser.add_argument("--source-ref", default=os.getenv("SOURCE_REF", "main"))
+    parser.add_argument("--output", default="security-statement.yaml")
+    parser.add_argument("--skip-govulncheck", action="store_true", help="Do not execute govulncheck.")
+    return parser.parse_args()
+
+
+def normalize_cve_id(candidate: str) -> str:
+    return candidate.strip().upper()
+
+
+def collect_cve_ids(issue_title: str, issue_body: str, cli_cve_ids: Iterable[str]) -> List[str]:
+    found = []
+    for raw in cli_cve_ids:
+        if raw:
+            found.extend(CVE_PATTERN.findall(raw))
+            if not CVE_PATTERN.search(raw):
+                found.append(raw.strip().upper())
+
+    found.extend(CVE_PATTERN.findall(issue_title or ""))
+    found.extend(CVE_PATTERN.findall(issue_body or ""))
+
+    deduped = []
+    seen = set()
+    for item in found:
+        normalized = normalize_cve_id(item)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            deduped.append(normalized)
+    return deduped
+
+
+def run_govulncheck() -> Tuple[int, str, str]:
+    command = ["go", "run", "golang.org/x/vuln/cmd/govulncheck@latest", "-json", "./..."]
+    completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    return completed.returncode, completed.stdout or "", completed.stderr or ""
+
+
+def parse_govulncheck_stream(stdout: str) -> Tuple[Dict[str, Dict[str, Any]], List[Dict[str, Any]]]:
+    osv_by_id: Dict[str, Dict[str, Any]] = {}
+    findings: List[Dict[str, Any]] = []
+    for raw_line in stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+
+        osv = payload.get("osv")
+        if isinstance(osv, dict) and osv.get("id"):
+            osv_by_id[osv["id"]] = osv
+
+        finding = payload.get("finding")
+        if isinstance(finding, dict):
+            findings.append(finding)
+    return osv_by_id, findings
+
+
+def classify_finding(trace: List[Dict[str, Any]]) -> str:
+    has_function = any(frame.get("function") for frame in trace)
+    has_package = any(frame.get("package") for frame in trace)
+    has_module = any(frame.get("module") for frame in trace)
+
+    if has_function:
+        return "reachable"
+    if has_package:
+        return "imported_not_called"
+    if has_module:
+        return "dependency_present"
+    return "unknown"
+
+
+def summarize_trace(trace: List[Dict[str, Any]]) -> str:
+    pieces: List[str] = []
+    for frame in trace[:5]:
+        module = frame.get("module")
+        package = frame.get("package")
+        function = frame.get("function")
+        value = function or package or module
+        if value:
+            pieces.append(value)
+    if not pieces:
+        return "no trace details reported"
+    return " -> ".join(pieces)
+
+
+def combine_reachability(values: Iterable[str]) -> str:
+    rank = {
+        "reachable": 4,
+        "imported_not_called": 3,
+        "dependency_present": 2,
+        "unknown": 1,
+        "not_detected": 0,
+    }
+    best = "not_detected"
+    for value in values:
+        if rank.get(value, 0) > rank.get(best, 0):
+            best = value
+    return best
+
+
+def finding_status(reachability: str, osv_matches: int, finding_count: int) -> str:
+    if reachability == "reachable":
+        return "affected"
+    if reachability in {"imported_not_called", "dependency_present"}:
+        return "potentially_affected"
+    if osv_matches > 0 and finding_count == 0:
+        return "not_affected"
+    return "not_detected_in_go_vuln_db"
+
+
+def to_yaml_scalar(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+
+    text = str(value)
+    if text == "":
+        return '""'
+    if "\n" in text:
+        raise ValueError("multiline string should be handled separately")
+    if SAFE_YAML_SCALAR.match(text) and text.lower() not in RESERVED_YAML_WORDS:
+        return text
+    return json.dumps(text)
+
+
+def dump_yaml(node: Any, indent: int = 0) -> List[str]:
+    pad = " " * indent
+
+    if isinstance(node, dict):
+        if not node:
+            return [pad + "{}"]
+        lines: List[str] = []
+        for key, value in node.items():
+            key_text = str(key)
+            if isinstance(value, str) and "\n" in value:
+                lines.append(f"{pad}{key_text}: |-")
+                for block_line in value.splitlines():
+                    lines.append(f"{pad}  {block_line}")
+                if value.endswith("\n"):
+                    lines.append(f"{pad}  ")
+            elif isinstance(value, (dict, list)):
+                lines.append(f"{pad}{key_text}:")
+                lines.extend(dump_yaml(value, indent + 2))
+            else:
+                lines.append(f"{pad}{key_text}: {to_yaml_scalar(value)}")
+        return lines
+
+    if isinstance(node, list):
+        if not node:
+            return [pad + "[]"]
+        lines = []
+        for item in node:
+            if isinstance(item, str) and "\n" in item:
+                lines.append(pad + "- |-")
+                for block_line in item.splitlines():
+                    lines.append(f"{pad}  {block_line}")
+            elif isinstance(item, (dict, list)):
+                lines.append(pad + "-")
+                lines.extend(dump_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}- {to_yaml_scalar(item)}")
+        return lines
+
+    return [pad + to_yaml_scalar(node)]
+
+
+def main() -> int:
+    args = parse_args()
+
+    cve_ids = collect_cve_ids(args.issue_title, args.issue_body, args.cve_id)
+    now = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+    govulncheck_stdout = ""
+    govulncheck_stderr = ""
+    govulncheck_exit = -1
+    if not args.skip_govulncheck:
+        govulncheck_exit, govulncheck_stdout, govulncheck_stderr = run_govulncheck()
+
+    osv_by_id, findings = parse_govulncheck_stream(govulncheck_stdout)
+    findings_by_osv = defaultdict(list)
+    for finding in findings:
+        osv_id = finding.get("osv")
+        if osv_id:
+            findings_by_osv[osv_id].append(finding)
+
+    investigations: List[Dict[str, Any]] = []
+    for cve_id in cve_ids:
+        matching_osv = []
+        for osv in osv_by_id.values():
+            aliases = [alias.upper() for alias in osv.get("aliases", [])]
+            if cve_id == osv.get("id", "").upper() or cve_id in aliases:
+                matching_osv.append(osv)
+
+        finding_views: List[FindingView] = []
+        for osv in matching_osv:
+            for finding in findings_by_osv.get(osv["id"], []):
+                trace = finding.get("trace") or []
+                finding_views.append(
+                    FindingView(
+                        osv_id=osv["id"],
+                        reachability=classify_finding(trace),
+                        fixed_version=finding.get("fixed_version", ""),
+                        trace_summary=summarize_trace(trace),
+                    )
+                )
+
+        reachability = combine_reachability([view.reachability for view in finding_views])
+        status = finding_status(reachability, len(matching_osv), len(finding_views))
+
+        summary = next((osv.get("summary", "") for osv in matching_osv if osv.get("summary")), "")
+        details = next((osv.get("details", "") for osv in matching_osv if osv.get("details")), "")
+        if not matching_osv:
+            summary = "No matching Go advisory found for this CVE."
+            details = (
+                "The CVE might target a component outside of Go modules or a package "
+                "that is not in the Cloudbeat dependency graph."
+            )
+
+        references = []
+        for osv in matching_osv:
+            for ref in osv.get("references", []):
+                if isinstance(ref, dict) and ref.get("url"):
+                    references.append(ref["url"])
+        references = sorted(set(references))
+
+        aliases = sorted(
+            {
+                alias.upper()
+                for osv in matching_osv
+                for alias in osv.get("aliases", [])
+                if alias.upper() != cve_id
+            }
+        )
+        fixed_versions = sorted({view.fixed_version for view in finding_views if view.fixed_version})
+
+        investigations.append(
+            {
+                "cve_id": cve_id,
+                "status": status,
+                "reachability": reachability,
+                "matching_go_advisories": [osv.get("id") for osv in matching_osv],
+                "metadata": {
+                    "summary": summary or "No summary returned from govulncheck advisory metadata.",
+                    "details": details or "No additional details returned from govulncheck advisory metadata.",
+                    "aliases": aliases,
+                    "references": references,
+                },
+                "evidence": {
+                    "findings_count": len(finding_views),
+                    "fixed_versions": fixed_versions,
+                    "traces": [view.trace_summary for view in finding_views[:5]],
+                },
+            }
+        )
+
+    statuses = {inv["status"] for inv in investigations}
+    if "affected" in statuses:
+        overall_assessment = "affected"
+    elif "potentially_affected" in statuses:
+        overall_assessment = "review_required"
+    elif statuses == {"not_affected"}:
+        overall_assessment = "not_affected"
+    elif statuses:
+        overall_assessment = "inconclusive"
+    else:
+        overall_assessment = "inconclusive"
+
+    statement = {
+        "schema_version": "1.0",
+        "statement_type": "cloudbeat_cve_investigation",
+        "generated_at": now,
+        "trigger": {
+            "mode": args.trigger_mode,
+            "issue_repository": args.issue_repository,
+            "issue_number": args.issue_number,
+        },
+        "analysis_context": {
+            "source_repository": args.source_repository,
+            "source_ref": args.source_ref,
+            "issue_title": args.issue_title,
+            "cloudbeat_keyword_present": "cloudbeat" in (args.issue_title + " " + args.issue_body).lower(),
+            "cve_ids": cve_ids,
+        },
+        "tooling": {
+            "govulncheck": {
+                "executed": not args.skip_govulncheck,
+                "exit_code": govulncheck_exit,
+                "stderr": govulncheck_stderr.strip(),
+            }
+        },
+        "overall_assessment": overall_assessment,
+        "investigations": investigations,
+        "recommendation": (
+            "If any status is affected or potentially_affected, assign an engineer for patch planning "
+            "and verify package upgrade constraints in go.mod/go.sum."
+        ),
+    }
+
+    yaml_payload = "\n".join(dump_yaml(statement)) + "\n"
+    with open(args.output, "w", encoding="utf-8") as handle:
+        handle.write(yaml_payload)
+
+    print(f"Wrote security statement to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/cve-investigation.yml
+++ b/.github/workflows/cve-investigation.yml
@@ -1,0 +1,214 @@
+name: Cloudbeat CVE Investigation
+
+on:
+  workflow_call:
+    inputs:
+      issue_repository:
+        description: "Repository that owns the CVE issue (for example elastic/security)"
+        required: false
+        type: string
+        default: ""
+      issue_number:
+        description: "Issue number where the result should be posted"
+        required: true
+        type: string
+      issue_title:
+        description: "Issue title used for CVE extraction/context"
+        required: true
+        type: string
+      issue_body:
+        description: "Issue body used for CVE extraction/context"
+        required: false
+        type: string
+        default: ""
+      cve_id:
+        description: "Optional explicit CVE ID override"
+        required: false
+        type: string
+        default: ""
+      trigger_mode:
+        description: "How this run was triggered (comment, title_match, manual)"
+        required: false
+        type: string
+        default: manual
+      source_repository:
+        description: "Repository containing Cloudbeat source code to analyze"
+        required: false
+        type: string
+        default: elastic/cloudbeat
+      source_ref:
+        description: "Git ref in source_repository to checkout"
+        required: false
+        type: string
+        default: main
+      target_repository:
+        description: "Repository where investigation comment is posted"
+        required: false
+        type: string
+        default: ""
+      post_comment:
+        description: "Post generated YAML as a comment on the issue"
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      issue_comment_token:
+        description: "Optional token with access to target_repository issues"
+        required: false
+
+  workflow_dispatch:
+    inputs:
+      issue_repository:
+        description: "Repository that owns the CVE issue (for example elastic/security)"
+        required: false
+        type: string
+      issue_number:
+        description: "Issue number where the result should be posted"
+        required: true
+        type: string
+      issue_title:
+        description: "Issue title used for CVE extraction/context"
+        required: true
+        type: string
+      issue_body:
+        description: "Issue body used for CVE extraction/context"
+        required: false
+        type: string
+      cve_id:
+        description: "Optional explicit CVE ID override"
+        required: false
+        type: string
+      trigger_mode:
+        description: "How this run was triggered (comment, title_match, manual)"
+        required: false
+        default: manual
+        type: string
+      source_repository:
+        description: "Repository containing Cloudbeat source code to analyze"
+        required: false
+        default: elastic/cloudbeat
+        type: string
+      source_ref:
+        description: "Git ref in source_repository to checkout"
+        required: false
+        default: main
+        type: string
+      target_repository:
+        description: "Repository where investigation comment is posted"
+        required: false
+        type: string
+      post_comment:
+        description: "Post generated YAML as a comment on the issue"
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  investigate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      ISSUE_REPOSITORY: ${{ inputs.issue_repository }}
+      ISSUE_NUMBER: ${{ inputs.issue_number }}
+      ISSUE_TITLE: ${{ inputs.issue_title }}
+      ISSUE_BODY: ${{ inputs.issue_body }}
+      SOURCE_REPOSITORY: ${{ inputs.source_repository }}
+      SOURCE_REF: ${{ inputs.source_ref }}
+      TRIGGER_MODE: ${{ inputs.trigger_mode }}
+      TARGET_REPOSITORY: ${{ inputs.target_repository }}
+      CVE_ID: ${{ inputs.cve_id }}
+      POST_COMMENT: ${{ inputs.post_comment }}
+    steps:
+      - name: Checkout Cloudbeat source repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.SOURCE_REPOSITORY }}
+          ref: ${{ env.SOURCE_REF }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Generate security statement (YAML)
+        run: |
+          args=(
+            --issue-repository "$ISSUE_REPOSITORY"
+            --issue-number "$ISSUE_NUMBER"
+            --issue-title "$ISSUE_TITLE"
+            --issue-body "$ISSUE_BODY"
+            --trigger-mode "$TRIGGER_MODE"
+            --source-repository "$SOURCE_REPOSITORY"
+            --source-ref "$SOURCE_REF"
+            --output security-statement.yaml
+          )
+
+          if [ -n "$CVE_ID" ]; then
+            args+=(--cve-id "$CVE_ID")
+          fi
+
+          python3 .github/scripts/generate_cve_security_statement.py "${args[@]}"
+
+      - name: Upload statement artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudbeat-cve-security-statement
+          path: security-statement.yaml
+
+      - name: Publish statement in workflow summary
+        run: |
+          {
+            echo "## Cloudbeat CVE security statement"
+            echo ""
+            echo "Repository: \`$SOURCE_REPOSITORY@$SOURCE_REF\`"
+            echo ""
+            echo "\`\`\`yaml"
+            cat security-statement.yaml
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment statement on target issue
+        if: ${{ inputs.post_comment && inputs.issue_number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.issue_comment_token != '' && secrets.issue_comment_token || github.token }}
+        run: |
+          issue_repo="$TARGET_REPOSITORY"
+          if [ -z "$issue_repo" ]; then
+            if [ -n "$ISSUE_REPOSITORY" ]; then
+              issue_repo="$ISSUE_REPOSITORY"
+            else
+              issue_repo="${GITHUB_REPOSITORY}"
+            fi
+          fi
+
+          comment_file="$(mktemp)"
+          {
+            echo "<!-- cloudbeat-cve-security-statement -->"
+            echo "### Cloudbeat automated CVE investigation"
+            echo ""
+            echo "Source analyzed: \`$SOURCE_REPOSITORY@$SOURCE_REF\`"
+            echo ""
+            echo "\`\`\`yaml"
+            cat security-statement.yaml
+            echo "\`\`\`"
+          } > "$comment_file"
+
+          existing_comment_id="$(gh api "repos/${issue_repo}/issues/${ISSUE_NUMBER}/comments" \
+            --jq 'map(select(.body | contains("<!-- cloudbeat-cve-security-statement -->"))) | last | .id // empty')"
+
+          if [ -n "$existing_comment_id" ]; then
+            gh api "repos/${issue_repo}/issues/comments/${existing_comment_id}" \
+              --method PATCH \
+              -f body@"$comment_file"
+          else
+            gh api "repos/${issue_repo}/issues/${ISSUE_NUMBER}/comments" \
+              --method POST \
+              -f body@"$comment_file"
+          fi

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ We use [Hermit](https://cashapp.github.io/hermit/usage/get-started/) to manage o
 
 ___
 
-> **Note** If you are a developer or contributor, or if you are looking for additional information, please visit our [development documentation](dev-docs/Development.md)
+> **Note** If you are a developer or contributor, or if you are looking for additional information, please visit our [development documentation](dev-docs/Development.md). For CVE issue automation across repositories, see [CVE automation](dev-docs/CVE-Automation.md).

--- a/dev-docs/CVE-Automation.md
+++ b/dev-docs/CVE-Automation.md
@@ -1,0 +1,117 @@
+# Cloudbeat CVE Automation
+
+This document describes how to automate Cloudbeat CVE investigations when the CVE issue is created in a private repository (for example, `elastic/security`).
+
+## What this solves
+
+- CVE issue is opened in a **private** repository.
+- Investigation runs against **Cloudbeat source code** in `elastic/cloudbeat`.
+- A YAML security statement is generated automatically.
+- The statement is posted back to the private issue as a comment.
+
+## Architecture
+
+1. A workflow in `elastic/security` receives the trigger:
+   - **On-demand**: issue comment is `/cve`.
+   - **Automatic**: issue title contains `cloudbeat`.
+2. That workflow calls the reusable workflow in this repository:
+   - `.github/workflows/cve-investigation.yml`
+3. The reusable workflow:
+   - checks out `elastic/cloudbeat`
+   - runs `.github/scripts/generate_cve_security_statement.py`
+   - uses `govulncheck` JSON output for dependency/reachability evidence
+   - emits `security-statement.yaml`
+   - comments the YAML back on the issue
+
+The caller repository stays private, while the analysis logic lives with Cloudbeat source.
+
+## Required permissions
+
+In the caller workflow (`elastic/security`), use:
+
+```yaml
+permissions:
+  contents: read
+  issues: write
+```
+
+This allows:
+- reading reusable workflow content from `elastic/cloudbeat`
+- posting issue comments in `elastic/security`
+
+## Caller workflow example (`elastic/security`)
+
+```yaml
+name: Cloudbeat CVE Investigation Trigger
+
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  cve_on_demand:
+    if: >
+      github.event_name == 'issue_comment' &&
+      startsWith(github.event.comment.body, '/cve') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    uses: elastic/cloudbeat/.github/workflows/cve-investigation.yml@main
+    with:
+      issue_repository: ${{ github.repository }}
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}
+      issue_body: ${{ github.event.issue.body }}
+      trigger_mode: comment
+      source_repository: elastic/cloudbeat
+      source_ref: main
+      target_repository: ${{ github.repository }}
+      post_comment: true
+    secrets: inherit
+
+  cve_auto_cloudbeat_title:
+    if: >
+      github.event_name == 'issues' &&
+      contains(toLower(github.event.issue.title), 'cloudbeat')
+    uses: elastic/cloudbeat/.github/workflows/cve-investigation.yml@main
+    with:
+      issue_repository: ${{ github.repository }}
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}
+      issue_body: ${{ github.event.issue.body }}
+      trigger_mode: title_match
+      source_repository: elastic/cloudbeat
+      source_ref: main
+      target_repository: ${{ github.repository }}
+      post_comment: true
+    secrets: inherit
+```
+
+## Notes
+
+- The generator extracts CVE IDs from:
+  - explicit input (`cve_id`)
+  - issue title/body (regex `CVE-YYYY-NNNN...`)
+- If no matching Go advisory is found, the statement marks the result as `not_detected_in_go_vuln_db`.
+- If reachable vulnerable functions are found, the statement marks status as `affected`.
+
+## Manual test
+
+This repository workflow can also run manually (`workflow_dispatch`) for validation:
+
+1. Open **Actions** → **Cloudbeat CVE Investigation**
+2. Fill:
+   - `issue_number`
+   - `issue_title`
+   - optional `issue_body` / `cve_id`
+3. Run and inspect:
+   - job summary
+   - `cloudbeat-cve-security-statement` artifact


### PR DESCRIPTION
### Summary of your changes
This PR introduces an automated CVE investigation workflow for Cloudbeat, designed to bridge private `elastic/security` issues with public `cloudbeat` source code analysis.

The solution includes:
-   A **reusable GitHub Actions workflow** (`.github/workflows/cve-investigation.yml`) in the `cloudbeat` repository. This workflow can be triggered by external repositories (e.g., `elastic/security`) via `workflow_call` or manually via `workflow_dispatch`. It checks out the `cloudbeat` source, runs CVE analysis, and posts/updates a structured YAML security statement as a comment on the originating issue.
-   A **Python script** (`.github/scripts/generate_cve_security_statement.py`) that extracts CVE IDs, utilizes `govulncheck` for reachability analysis, and generates a detailed YAML security statement.
-   **Comprehensive documentation** (`dev-docs/CVE-Automation.md`) providing guidance for setting up trigger workflows in the private `elastic/security` repository. This includes examples for both on-demand `/cve` comment triggers and automatic triggers based on issue title matching, along with necessary GitHub App permissions.
-   An update to `README.md` to link to the new automation documentation.

This automation addresses the challenge of running analysis against a public repository (`cloudbeat`) while posting results back to a private issue (`elastic/security`), supporting both manual and automatic triggering mechanisms.

### Screenshot/Data
The primary output is a YAML security statement, an example of which is generated by the `generate_cve_security_statement.py` script. This statement includes:
-   Trigger context (e.g., issue URL, CVE ID)
-   List of identified CVEs
-   `govulncheck` advisory matches
-   Reachability classification (e.g., `reachable`, `imported_not_called`)
-   Overall assessment

### Related Issues
<!-- No specific related issues were provided in the conversation. -->

### Checklist
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?
-   [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
-   [ ] Add relevant unit tests
-   [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)

---
<p><a href="https://cursor.com/agents?id=bc-6b2ef06d-0fa0-4968-bf94-f44efe5f8fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b2ef06d-0fa0-4968-bf94-f44efe5f8fc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

